### PR TITLE
removed View dependency and increased use case testability

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ If you click `Leave Room` on chat room screen, you can leave the room and you'll
 ## Clean Architecture
 Separation of Concerns: 
 The interactor is part of the application core, and it is responsible for handling the business logic related to corresponding use case. 
-It communicates with the outer layers (controller, presenter and database) through interfaces (InputBoundary, OutputBoundary, and DBGateway), 
+It communicates with the outer layers (controller, presenter and database_and_drivers) through interfaces (InputBoundary, OutputBoundary, and DBGateway), 
 ensuring a clear separation of concerns between different layers of the application.
 The Interactor does not have any direct dependencies on specific frameworks or libraries. 
 Its dependencies are abstracted through interfaces, and the actual implementations are provided externally (injected) during runtime. 
@@ -58,7 +58,7 @@ can be used interchangeably with `View` or each corresponding interface without 
 **Dependency Inversion Principle (DIP)**: By using interfaces and data transfer object(which is called models here), dependencies between 
 layers could be inverted and therefore, high level classes does not directly depend on lower level classes. 
 For example, `UserInteractor` can receive data from users through `UserModel` object and `UserInputBoundary` and interact with 
-database through `UserDBGateway`. Hence, `UserInteractor` does not depend on outer layers such as controller and database.
+database_and_drivers through `UserDBGateway`. Hence, `UserInteractor` does not depend on outer layers such as controller and database_and_drivers.
 This inversion of dependencies allows for easier interacting between layers without affecting core business logic in high level.
 
 ## Design Patterns
@@ -66,7 +66,7 @@ TODO - Singleton pattern
 
 ## Test Coverage
 We aimed for near perfect coverage across the board and manage to achieve XX% class coverage and XX% line coverage. <br>
-In the database package we achieved 83% class coverage and 64% line coverage because the HttpClient is impractical to test, 
+In the database_and_drivers package we achieved 83% class coverage and 64% line coverage because the HttpClient is impractical to test, 
 as we'd have to simulate a server. Otherwise, we tested the core functionality of the DBAccess's in the package.
 
 ## Java Doc
@@ -83,7 +83,7 @@ Use case:<br> `src/main/java/host_room`<br>
 
 Input and data model:<br> `src/main/java/models`<br>
 
-Gateway and DBAccess:<br> `src/main/java/database`<br>
+Gateway and DBAccess:<br> `src/main/java/database_and_drivers`<br>
 
 View:<br> `src/main/java/views`<br>
 

--- a/build.gradle
+++ b/build.gradle
@@ -10,10 +10,9 @@ sourceCompatibility = JavaVersion.VERSION_11
 targetCompatibility = JavaVersion.VERSION_11
 
 dependencies {
-    implementation 'junit:junit:4.13.1'
     implementation 'com.google.code.gson:gson:2.10.1'
     implementation 'org.mindrot:jbcrypt:0.4'
-    testImplementation('org.junit.jupiter:junit-jupiter:5.6.0')
+    testImplementation 'org.junit.jupiter:junit-jupiter:5.6.0'
     testImplementation 'org.mockito:mockito-core:3.12.4'
 }
 

--- a/src/main/java/Main.java
+++ b/src/main/java/Main.java
@@ -1,7 +1,7 @@
-import database.*;
+import database_and_drivers.*;
 import views.*;
-import database.converters.RoomConverter;
-import database.converters.UserConverter;
+import database_and_drivers.converters.RoomConverter;
+import database_and_drivers.converters.UserConverter;
 import use_cases_and_adapters.host_room.*;
 import use_cases_and_adapters.join_room.*;
 import use_cases_and_adapters.leave_room.*;
@@ -14,6 +14,7 @@ public class Main {
     private static final String larkSoundFilePath = "/src/main/assets/lark_sound.wav";
     public static void main(String[] args) {
         HttpClient httpClient = new HttpClient(API_URL);
+        LarkSoundPlayer larkSoundPlayer = new LarkSoundPlayer(larkSoundFilePath);
 
         RoomConverter roomConverter = new RoomConverter();
         UserConverter userConverter = new UserConverter();
@@ -35,7 +36,7 @@ public class Main {
         LeaveRoomController leaveRoomController = new LeaveRoomController(leaveRoomInteractor);
 
         MessagePresenter sendMessagePresenter = new MessagePresenter();
-        MessageInteractor interactor = new MessageInteractor(roomDBAccess, sendMessagePresenter, larkSoundFilePath);
+        MessageInteractor interactor = new MessageInteractor(roomDBAccess, sendMessagePresenter, larkSoundPlayer);
         MessageController sendMessageController = new MessageController(interactor);
         RoomView roomView = new RoomView(leaveRoomController, sendMessageController);
 

--- a/src/main/java/Main.java
+++ b/src/main/java/Main.java
@@ -56,6 +56,6 @@ public class Main {
         leaveRoomPresenter.setView(joinOrHostView);
         sendMessagePresenter.setView(roomView);
 
-        welcomeView.prepareGUI(); // launch app
+        welcomeView.prepareGUI(null); // launch app
     }
 }

--- a/src/main/java/database_and_drivers/DBAccess.java
+++ b/src/main/java/database_and_drivers/DBAccess.java
@@ -1,10 +1,10 @@
-package database;
+package database_and_drivers;
 
 import com.google.gson.Gson;
 import com.google.gson.JsonArray;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
-import database.converters.JsonConverter;
+import database_and_drivers.converters.JsonConverter;
 
 import java.io.IOException;
 import java.util.ArrayList;

--- a/src/main/java/database_and_drivers/HttpClient.java
+++ b/src/main/java/database_and_drivers/HttpClient.java
@@ -1,4 +1,4 @@
-package database;
+package database_and_drivers;
 
 import java.io.BufferedReader;
 import java.io.IOException;

--- a/src/main/java/database_and_drivers/LarkSoundPlayer.java
+++ b/src/main/java/database_and_drivers/LarkSoundPlayer.java
@@ -1,0 +1,45 @@
+package database_and_drivers;
+
+import use_cases_and_adapters.messaging.LarkSoundPlayerGateway;
+
+import javax.sound.sampled.*;
+import java.io.File;
+import java.io.IOException;
+
+/**
+ * Implementation of the LarkSoundPlayerGateway that plays a specified sound file.
+ */
+public class LarkSoundPlayer implements LarkSoundPlayerGateway {
+    private final String soundFilePath;
+
+    /**
+     * Constructor for LarkSoundPlayer.
+     *
+     * @param soundFilePath The relative path to the sound file to be played.
+     */
+    public LarkSoundPlayer(String soundFilePath) {
+        this.soundFilePath = soundFilePath;
+    }
+
+    /**
+     * Plays the lark sound.
+     * This method attempts to open and play the sound file specified in the constructor.
+     * If the file is not found or there is an issue playing the sound, a RuntimeException will be thrown.
+     *
+     * @throws RuntimeException if there is an error playing the sound.
+     */
+    @Override
+    public void playLarkSound() {
+        String userDir = System.getProperty("user.dir");
+        File soundFile = new File(userDir + soundFilePath);
+
+        // notice "try with resources" means that the input stream will be closed automatically
+        try (AudioInputStream audioInputStream = AudioSystem.getAudioInputStream(soundFile)) {
+            Clip clip = AudioSystem.getClip();
+            clip.open(audioInputStream);
+            clip.start();
+        } catch (UnsupportedAudioFileException | LineUnavailableException | IOException e) {
+            throw new RuntimeException("Error playing sound", e);
+        }
+    }
+}

--- a/src/main/java/database_and_drivers/RoomDBAccess.java
+++ b/src/main/java/database_and_drivers/RoomDBAccess.java
@@ -1,8 +1,8 @@
-package database;
+package database_and_drivers;
 
 import java.util.List;
 
-import database.converters.RoomConverter;
+import database_and_drivers.converters.RoomConverter;
 import use_cases_and_adapters.RoomDBModel;
 import use_cases_and_adapters.host_room.HostRoomDBGateway;
 import use_cases_and_adapters.join_room.JoinRoomDBGateway;

--- a/src/main/java/database_and_drivers/UserDBAccess.java
+++ b/src/main/java/database_and_drivers/UserDBAccess.java
@@ -1,6 +1,6 @@
-package database;
+package database_and_drivers;
 
-import database.converters.UserConverter;
+import database_and_drivers.converters.UserConverter;
 import use_cases_and_adapters.UserDBModel;
 import use_cases_and_adapters.signup_and_login.UserDBGateway;
 

--- a/src/main/java/database_and_drivers/converters/JsonConverter.java
+++ b/src/main/java/database_and_drivers/converters/JsonConverter.java
@@ -1,4 +1,4 @@
-package database.converters;
+package database_and_drivers.converters;
 
 import com.google.gson.JsonObject;
 

--- a/src/main/java/database_and_drivers/converters/RoomConverter.java
+++ b/src/main/java/database_and_drivers/converters/RoomConverter.java
@@ -1,4 +1,4 @@
-package database.converters;
+package database_and_drivers.converters;
 
 import com.google.gson.JsonArray;
 import com.google.gson.JsonElement;

--- a/src/main/java/database_and_drivers/converters/UserConverter.java
+++ b/src/main/java/database_and_drivers/converters/UserConverter.java
@@ -1,4 +1,4 @@
-package database.converters;
+package database_and_drivers.converters;
 
 import com.google.gson.JsonObject;
 import use_cases_and_adapters.UserDBModel;

--- a/src/main/java/use_cases_and_adapters/Viewable.java
+++ b/src/main/java/use_cases_and_adapters/Viewable.java
@@ -6,6 +6,6 @@ import javax.swing.*;
  */
 public interface Viewable {
     JPanel createPanel();
-
-    void prepareGUI();
+    void prepareGUI(String msgHistory);
+    void displayPopUpMessage(String msg);
 }

--- a/src/main/java/use_cases_and_adapters/host_room/HostRoomPresenter.java
+++ b/src/main/java/use_cases_and_adapters/host_room/HostRoomPresenter.java
@@ -1,9 +1,7 @@
 package use_cases_and_adapters.host_room;
 
-import views.View;
 import use_cases_and_adapters.Viewable;
 
-import javax.swing.JOptionPane;
 public class HostRoomPresenter implements HostRoomOutputBoundary {
     private Viewable view;
     /**
@@ -12,17 +10,16 @@ public class HostRoomPresenter implements HostRoomOutputBoundary {
      */
     @Override
     public void prepareRoomView(String messageHistory) {
-        View.messageHistory = messageHistory;
-        view.prepareGUI();
+        view.prepareGUI(messageHistory);
     }
 
     @Override
     public void prepareMultipleHostingView() {
-        JOptionPane.showMessageDialog(null, "Already hosting room");
+        view.displayPopUpMessage("You're already hosting another room.");
     }
 
     public void prepareDuplicateNameView() {
-        JOptionPane.showMessageDialog(null, "Room with this name already exists");
+        view.displayPopUpMessage("A room with this name already exists.");
     }
 
     public void setView(Viewable view) {

--- a/src/main/java/use_cases_and_adapters/join_room/JoinRoomPresenter.java
+++ b/src/main/java/use_cases_and_adapters/join_room/JoinRoomPresenter.java
@@ -1,10 +1,6 @@
 package use_cases_and_adapters.join_room;
 
-
-import views.View;
 import use_cases_and_adapters.Viewable;
-
-import javax.swing.*;
 
 /**
  * A presenter for join room use case.
@@ -20,8 +16,7 @@ public class JoinRoomPresenter implements JoinRoomOutputBoundary {
      */
     @Override
     public void prepareRoomView(String messageHistory){
-        View.messageHistory = messageHistory;
-        view.prepareGUI();
+        view.prepareGUI(messageHistory);
     }
 
     /**
@@ -29,8 +24,7 @@ public class JoinRoomPresenter implements JoinRoomOutputBoundary {
      */
     @Override
     public void prepareFailView(){
-
-        JOptionPane.showMessageDialog(null, "No Such Room Found!");
+        view.displayPopUpMessage("No Such Room Found!");
     }
 
     /**

--- a/src/main/java/use_cases_and_adapters/leave_room/LeaveRoomPresenter.java
+++ b/src/main/java/use_cases_and_adapters/leave_room/LeaveRoomPresenter.java
@@ -2,8 +2,6 @@ package use_cases_and_adapters.leave_room;
 
 import use_cases_and_adapters.Viewable;
 
-import javax.swing.JOptionPane;
-
 /**
  * The LeaveRoomPresenter class handles the view presentation after a user leaves a room.
  * It provides an implementation of the prepareJoinOrHostView and prepareFailedToLeaveRoomView methods
@@ -17,7 +15,7 @@ public class LeaveRoomPresenter implements LeaveRoomOutputBoundary {
      */
     @Override
     public void prepareJoinOrHostView() {
-        view.prepareGUI();
+        view.prepareGUI(null);
     }
 
     /**
@@ -25,8 +23,9 @@ public class LeaveRoomPresenter implements LeaveRoomOutputBoundary {
      */
     @Override
     public void prepareFailedToLeaveRoomView() {
-        JOptionPane.showMessageDialog(null, "Failed to leave the room");
+        view.displayPopUpMessage("Failed to leave the room.");
     }
+
     public void setView(Viewable view) {
         this.view = view;
     }

--- a/src/main/java/use_cases_and_adapters/messaging/LarkSoundPlayerGateway.java
+++ b/src/main/java/use_cases_and_adapters/messaging/LarkSoundPlayerGateway.java
@@ -1,0 +1,8 @@
+package use_cases_and_adapters.messaging;
+
+/**
+ * This class is interface that allows the interactor to play the Lark sound.
+ */
+public interface LarkSoundPlayerGateway {
+    void playLarkSound();
+}

--- a/src/main/java/use_cases_and_adapters/messaging/MessageInteractor.java
+++ b/src/main/java/use_cases_and_adapters/messaging/MessageInteractor.java
@@ -5,13 +5,6 @@ import entities.Room;
 import entities.User;
 import use_cases_and_adapters.RoomDBModel;
 
-import java.io.*;
-import javax.sound.sampled.AudioInputStream;
-import javax.sound.sampled.AudioSystem;
-import javax.sound.sampled.Clip;
-import javax.sound.sampled.LineUnavailableException;
-import javax.sound.sampled.UnsupportedAudioFileException;
-
 /**
  * The MessageInteractor class implements the MessageInputBoundary interface and is responsible for handling
  * message-related requests. It interacts with the database and presenter to manage messages and their presentation.
@@ -19,19 +12,19 @@ import javax.sound.sampled.UnsupportedAudioFileException;
 public class MessageInteractor implements MessageInputBoundary {
     private final MessageDBGateway database;
     private final MessageOutputBoundary presenter;
-    private final String larkSoundFilePath;
+    private final LarkSoundPlayerGateway larkSoundPlayer;
 
     /**
      * Constructs a MessageInteractor object with the given dependencies.
      *
      * @param database           The RoomDBGateway to access room-related data.
      * @param presenter          The MessageOutputBoundary to present messages to the user.
-     * @param larkSoundFilePath  The file path to the lark sound file.
+     * @param larkSoundPlayer    The LarkSoundPlayerGateway to allow this interactor to play the lark sound when required.
      */
-    public MessageInteractor(MessageDBGateway database, MessageOutputBoundary presenter, String larkSoundFilePath) {
+    public MessageInteractor(MessageDBGateway database, MessageOutputBoundary presenter, LarkSoundPlayerGateway larkSoundPlayer) {
         this.database = database;
         this.presenter = presenter;
-        this.larkSoundFilePath = larkSoundFilePath;
+        this.larkSoundPlayer = larkSoundPlayer;
     }
 
     /**
@@ -46,7 +39,7 @@ public class MessageInteractor implements MessageInputBoundary {
         }
 
         if (content.contains("/lark")) {
-            playLarkSound();
+            larkSoundPlayer.playLarkSound();
         }
 
         // create message entity
@@ -70,33 +63,9 @@ public class MessageInteractor implements MessageInputBoundary {
         String[] messages = messageHistory.split("\\n");
         String mostRecentMessage = messages[messages.length - 1];
         if (mostRecentMessage.contains("/lark")) { //checks whether the most recent message contains /lark
-            playLarkSound();
+            larkSoundPlayer.playLarkSound();
         }
 
         presenter.prepareRoomView(messageHistory);
     }
-
-    /**
-     * Plays the Lark Sound.
-     */
-    void playLarkSound() {
-        AudioInputStream audioInputStream = null;
-        try {
-            String userDir = System.getProperty("user.dir");
-            File soundFile = new File(userDir + larkSoundFilePath);
-            audioInputStream = AudioSystem.getAudioInputStream(soundFile);
-            Clip clip = AudioSystem.getClip();
-            clip.open(audioInputStream);
-            clip.start();
-        } catch (UnsupportedAudioFileException | LineUnavailableException | IOException e) {
-            e.printStackTrace();
-        } finally {
-            if (audioInputStream != null) {
-                try {
-                    audioInputStream.close();
-                } catch (IOException e) {
-                    e.printStackTrace();
-                }
-            }
-        }
-    }}
+}

--- a/src/main/java/use_cases_and_adapters/messaging/MessagePresenter.java
+++ b/src/main/java/use_cases_and_adapters/messaging/MessagePresenter.java
@@ -1,6 +1,5 @@
 package use_cases_and_adapters.messaging;
-import javax.swing.*;
-import views.View;
+
 import use_cases_and_adapters.Viewable;
 
 /**
@@ -17,8 +16,7 @@ public class MessagePresenter implements MessageOutputBoundary {
      */
     @Override
     public void prepareRoomView(String messageHistory) {
-        View.messageHistory = messageHistory;
-        view.prepareGUI();
+        view.prepareGUI(messageHistory);
     }
 
     /**
@@ -26,7 +24,7 @@ public class MessagePresenter implements MessageOutputBoundary {
      */
     @Override
     public void prepareMessageErrorView() {
-        JOptionPane.showMessageDialog(null, "Error sending message, cannot send an empty message!", "Message Error", JOptionPane.ERROR_MESSAGE);
+        view.displayPopUpMessage("You cannot send an empty message!");
     }
 
     /**

--- a/src/main/java/use_cases_and_adapters/signup_and_login/user_login/UserLoginPresenter.java
+++ b/src/main/java/use_cases_and_adapters/signup_and_login/user_login/UserLoginPresenter.java
@@ -2,8 +2,6 @@ package use_cases_and_adapters.signup_and_login.user_login;
 
 import use_cases_and_adapters.Viewable;
 
-import javax.swing.*;
-
 /**
  * A presenter for login use case.
  * This class implements UserLoginOutputBoundary to interact with UserLoginInteractor.
@@ -17,7 +15,7 @@ public class UserLoginPresenter implements UserLoginOutputBoundary{
      */
     @Override
     public void prepareJoinOrHostView() {
-        view.prepareGUI();
+        view.prepareGUI(null);
     }
 
     /**
@@ -25,8 +23,7 @@ public class UserLoginPresenter implements UserLoginOutputBoundary{
      */
     @Override
     public void prepareInvalidUsernameView() {
-        JOptionPane.showMessageDialog(null,
-                "Username does not exist.");
+        view.displayPopUpMessage("Username does not exist.");
     }
 
     /**
@@ -34,8 +31,7 @@ public class UserLoginPresenter implements UserLoginOutputBoundary{
      */
     @Override
     public void prepareInvalidPasswordView() {
-        JOptionPane.showMessageDialog(null,
-                "Password doesn't match username.");
+        view.displayPopUpMessage("Password doesn't match username.");
     }
 
     /**

--- a/src/main/java/use_cases_and_adapters/signup_and_login/user_signup/UserSignupPresenter.java
+++ b/src/main/java/use_cases_and_adapters/signup_and_login/user_signup/UserSignupPresenter.java
@@ -1,6 +1,5 @@
 package use_cases_and_adapters.signup_and_login.user_signup;
 
-import javax.swing.*;
 import use_cases_and_adapters.Viewable;
 
 /**
@@ -15,7 +14,7 @@ public class UserSignupPresenter implements UserSignupOutputBoundary {
      */
     @Override
     public void prepareJoinOrHostView() {
-        view.prepareGUI();
+        view.prepareGUI(null);
     }
 
     /**
@@ -23,7 +22,7 @@ public class UserSignupPresenter implements UserSignupOutputBoundary {
      */
     @Override
     public void prepareUsernameExistsView() {
-        JOptionPane.showMessageDialog(null, "Username already exists. Please try a different name.");
+        view.displayPopUpMessage("Username already exists. Please try a different name.");
     }
 
     /**

--- a/src/main/java/views/View.java
+++ b/src/main/java/views/View.java
@@ -10,10 +10,15 @@ public abstract class View extends JFrame implements Viewable {
     private static final int WIDTH = 600;
     private static final int HEIGHT = 400;
 
-    public static String messageHistory = "";
     private static JFrame currentFrame = null;
+    protected static String messageHistory = "";
 
-    public void prepareGUI() {
+    @Override
+    public void prepareGUI(String msgHistory) {
+
+        if (msgHistory != null) {
+            View.messageHistory = msgHistory;
+        }
 
         if(currentFrame != null) {
             currentFrame.dispose(); // close previous frame
@@ -30,6 +35,11 @@ public abstract class View extends JFrame implements Viewable {
         frame.setVisible(true);
 
         currentFrame = frame; // store reference to current frame (for when we want to close it)
+    }
+
+    @Override
+    public void displayPopUpMessage(String msg) {
+        JOptionPane.showMessageDialog(null, msg);
     }
 
     abstract public JPanel createPanel();

--- a/src/main/java/views/WelcomeView.java
+++ b/src/main/java/views/WelcomeView.java
@@ -32,7 +32,7 @@ public class WelcomeView extends View {
         JButton signupButton = new JButton("Sign up");
         signupButton.addActionListener(e -> {
             SignupView signUpView = new SignupView(this.signupController);
-            signUpView.prepareGUI();
+            signUpView.prepareGUI(null);
         });
         return signupButton;
     }
@@ -41,7 +41,7 @@ public class WelcomeView extends View {
         JButton loginButton = new JButton("Log in");
         loginButton.addActionListener(e -> {
             LoginView logInView = new LoginView(this.loginController);
-            logInView.prepareGUI();
+            logInView.prepareGUI(null);
         });
         return loginButton;
 

--- a/src/test/java/database_and_drivers/DBAccessTest.java
+++ b/src/test/java/database_and_drivers/DBAccessTest.java
@@ -1,9 +1,9 @@
-package database;
+package database_and_drivers;
 
 import com.google.gson.Gson;
 import com.google.gson.JsonArray;
 import com.google.gson.JsonObject;
-import database.converters.RoomConverter;
+import database_and_drivers.converters.RoomConverter;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mock;

--- a/src/test/java/database_and_drivers/HttpClientTest.java
+++ b/src/test/java/database_and_drivers/HttpClientTest.java
@@ -1,4 +1,4 @@
-package database;
+package database_and_drivers;
 
 import okhttp3.mockwebserver.MockResponse;
 import okhttp3.mockwebserver.MockWebServer;

--- a/src/test/java/database_and_drivers/LarkSoundPlayerTest.java
+++ b/src/test/java/database_and_drivers/LarkSoundPlayerTest.java
@@ -1,0 +1,26 @@
+package database_and_drivers;
+
+import use_cases_and_adapters.messaging.LarkSoundPlayerGateway;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class LarkSoundPlayerTest {
+
+    // currently commented since this is not headless,
+    // but uncommented we reach 100% line coverage for this class
+//    @Test
+//    void testPlayLarkSound() {
+//        // Provide the path to a valid audio file on your system
+//        String validSoundFilePath = "/src/main/assets/lark_sound.wav";
+//        LarkSoundPlayerGateway player = new LarkSoundPlayer(validSoundFilePath);
+//        assertDoesNotThrow(player::playLarkSound);
+//    }
+
+    @Test
+    void testPlayLarkSoundWithNonExistentFile() {
+        String invalidSoundFilePath = "/path/to/non/existent/file.wav";
+        LarkSoundPlayerGateway player = new LarkSoundPlayer(invalidSoundFilePath);
+        assertThrows(RuntimeException.class, player::playLarkSound);
+    }
+}

--- a/src/test/java/database_and_drivers/RoomDBAccessTest.java
+++ b/src/test/java/database_and_drivers/RoomDBAccessTest.java
@@ -1,6 +1,6 @@
-package database;
+package database_and_drivers;
 
-import database.converters.RoomConverter;
+import database_and_drivers.converters.RoomConverter;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mock;
@@ -8,7 +8,6 @@ import org.mockito.Mockito;
 import org.mockito.MockitoAnnotations;
 import use_cases_and_adapters.RoomDBModel;
 
-import java.io.IOException;
 import java.util.Collections;
 import java.util.List;
 
@@ -35,7 +34,7 @@ public class RoomDBAccessTest {
     }
 
     @Test
-    public void testGetRooms() throws IOException {
+    public void testGetRooms() {
         // here we are just checking that a call to getRooms is a call to getRows
         List<RoomDBModel> expectedRooms = Collections.singletonList(mockRoomDBModel);
         doReturn(expectedRooms).when(roomDBAccess).getRows();
@@ -44,7 +43,7 @@ public class RoomDBAccessTest {
     }
 
     @Test
-    public void testGetARoom() throws IOException {
+    public void testGetARoom() {
         // here we are just checking that a call to getARoom is a call to getRow
         int roomId = 123; // Example room ID
         doReturn(mockRoomDBModel).when(roomDBAccess).getARow(roomId);
@@ -53,7 +52,7 @@ public class RoomDBAccessTest {
     }
 
     @Test
-    public void testUpdateARoom() throws IOException {
+    public void testUpdateARoom() {
         // here we are just checking that a call to addARoom is a call to updateARow
         doNothing().when(roomDBAccess).updateARow(anyInt(), any());
         roomDBAccess.updateARoom(mockRoomDBModel);

--- a/src/test/java/database_and_drivers/UserDBAccessTest.java
+++ b/src/test/java/database_and_drivers/UserDBAccessTest.java
@@ -1,12 +1,11 @@
-package database;
+package database_and_drivers;
 
-import database.converters.UserConverter;
+import database_and_drivers.converters.UserConverter;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.*;
 import use_cases_and_adapters.UserDBModel;
 
-import java.io.IOException;
 import java.util.Collections;
 import java.util.List;
 
@@ -31,7 +30,7 @@ public class UserDBAccessTest {
     }
 
     @Test
-    public void testGetUsers() throws IOException {
+    public void testGetUsers() {
         // here we are just checking that a call to getUsers is a call to getRows
         List<UserDBModel> expectedUsers = Collections.singletonList(mockUserDBModel);
         doReturn(expectedUsers).when(userDBAccess).getRows();
@@ -40,7 +39,7 @@ public class UserDBAccessTest {
     }
 
     @Test
-    public void testAddAUser() throws IOException {
+    public void testAddAUser() {
         // here we are just checking that a call to addAUser is a call to updateARow
         doNothing().when(userDBAccess).updateARow(anyInt(), any());
         userDBAccess.addAUser(mockUserDBModel);

--- a/src/test/java/database_and_drivers/converters/RoomConverterTest.java
+++ b/src/test/java/database_and_drivers/converters/RoomConverterTest.java
@@ -1,4 +1,4 @@
-package database.converters;
+package database_and_drivers.converters;
 
 import com.google.gson.JsonObject;
 import use_cases_and_adapters.RoomDBModel;

--- a/src/test/java/database_and_drivers/converters/UserConverterTest.java
+++ b/src/test/java/database_and_drivers/converters/UserConverterTest.java
@@ -1,4 +1,4 @@
-package database.converters;
+package database_and_drivers.converters;
 
 import com.google.gson.JsonObject;
 import use_cases_and_adapters.UserDBModel;

--- a/src/test/java/use_cases_and_adapters/join_room/JoinRoomPresenterTest.java
+++ b/src/test/java/use_cases_and_adapters/join_room/JoinRoomPresenterTest.java
@@ -29,9 +29,12 @@ public class JoinRoomPresenterTest {
     @Test
     public void testPrepareRoomView(){
         presenter.prepareRoomView("[15:38:42] nadine: sup\n");
-        verify(mockView, times(1)).prepareGUI();
+        verify(mockView, times(1)).prepareGUI("[15:38:42] nadine: sup\n");
     }
 
-    // omitted testing the prepareInvalidCredentialsView method because it relies on a static method from Swing
-    // omitted testing the setView method because it is just a setter
+    @Test
+    void testPrepareFailView() {
+        presenter.prepareFailView();
+        verify(mockView, times(1)).displayPopUpMessage("No Such Room Found!");
+    }
 }

--- a/src/test/java/use_cases_and_adapters/leave_room/LeaveRoomPresenterTest.java
+++ b/src/test/java/use_cases_and_adapters/leave_room/LeaveRoomPresenterTest.java
@@ -22,6 +22,12 @@ class LeaveRoomPresenterTest {
     @Test
     void testPrepareJoinOrHostView() {
         leaveRoomPresenter.prepareJoinOrHostView();
-        verify(mockView, times(1)).prepareGUI(); // check that prepareGUI was called
+        verify(mockView, times(1)).prepareGUI(null); // check that prepareGUI was called
+    }
+
+    @Test
+    void testPrepareFailedToLeaveRoomView() {
+        leaveRoomPresenter.prepareFailedToLeaveRoomView();
+        verify(mockView, times(1)).displayPopUpMessage("Failed to leave the room.");
     }
 }

--- a/src/test/java/use_cases_and_adapters/messaging/MessageInteractorTest.java
+++ b/src/test/java/use_cases_and_adapters/messaging/MessageInteractorTest.java
@@ -9,7 +9,8 @@ import org.junit.jupiter.api.Test;
 import org.mockito.*;
 import java.util.ArrayList;
 import java.util.Arrays;
-import static org.junit.Assert.assertEquals;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.Mockito.*;
 

--- a/src/test/java/use_cases_and_adapters/messaging/MessageInteractorTest.java
+++ b/src/test/java/use_cases_and_adapters/messaging/MessageInteractorTest.java
@@ -24,10 +24,10 @@ public class MessageInteractorTest {
     @Mock
     private MessageDBGateway database;
 
-    private String larkSoundFilePath;
+    @Mock
+    private LarkSoundPlayerGateway larkSoundPlayer;
+
     private String testContent;
-    private String emptyContent;
-    private Integer roomID;
     private Integer hostID;
     private int userID;
     private int userID2;
@@ -35,18 +35,17 @@ public class MessageInteractorTest {
     @BeforeEach
     public void setUp() {
         MockitoAnnotations.openMocks(this);
-        larkSoundFilePath = "/src/main/assets/lark_sound.wav";
-        messageInteractor = new MessageInteractor(database, presenter, larkSoundFilePath);
+        messageInteractor = new MessageInteractor(database, presenter, larkSoundPlayer);
         messageInteractor = Mockito.spy(messageInteractor);
 
         //Initialize shared variables
-        roomID = 1;
+        Integer roomID = 1;
         userID = 111;
         userID2 = 222;
         hostID = 2;
         testContent = "Hello";
 
-        Room.setRoom(roomID, "Test Room", userID2, new ArrayList<>(Arrays.asList(userID, userID2)), ""); // simulate getting a room
+        Room.setRoom(roomID, "Test Room", userID2, new ArrayList<>(Arrays.asList(userID, userID2)), ""); // simulate being in a room
         User.setUser(userID, "", ""); // simulate logging in a user
         RoomDBModel testRoom = new RoomDBModel(roomID, "Test Room", hostID,new ArrayList<>(Arrays.asList(userID, userID2)), "" );
         when(database.getARoom(roomID)).thenReturn(testRoom);
@@ -54,7 +53,7 @@ public class MessageInteractorTest {
 
     @Test
     public void testHandleSendMessage_emptyContent() {
-        emptyContent = "";
+        String emptyContent = "";
         messageInteractor.handleSendMessage(emptyContent);
         verify(presenter).prepareMessageErrorView();
         verify(database, never()).getARoom(anyInt());
@@ -72,13 +71,13 @@ public class MessageInteractorTest {
         assertEquals(msg.getContent(), sentRoom.getMessageHistory());
         verify(presenter).prepareRoomView(sentRoom.getMessageHistory());
     }
-//    @Test
-//    public void testHandleSendMessage_withLarkSound() {
-//        String testContent = "Test message with /lark sound";
-//        messageInteractor.handleSendMessage(testContent);
-//        doNothing().when(messageInteractor).playLarkSound();
-//        verify(messageInteractor).playLarkSound();
-//    }
+
+    @Test
+    public void testHandleSendMessage_withLarkSound() {
+        String testContent = "Test message with /lark sound";
+        messageInteractor.handleSendMessage(testContent);
+        verify(larkSoundPlayer).playLarkSound();
+    }
 
     @Test
     public void testHandleRetrieveMessages_noLark() {
@@ -94,26 +93,21 @@ public class MessageInteractorTest {
         verify(presenter).prepareRoomView(messageHistory);
 
     }
-//
-//    @Test
-//    public void testHandleRetrieveMessages_WithLark(){
-//        // Prepare the test data
-//        String messageHistory = "User1: Hello\nUser2: /lark";
-//        RoomDBModel mockedRoom = new RoomDBModel(Room.getRoomID(), "Test Room", hostID, new ArrayList<>(Arrays.asList(userID, userID2)), messageHistory);
-//        when(database.getARoom(Room.getRoomID())).thenReturn(mockedRoom);
-//
-//        // Call the method to be tested
-//        messageInteractor.handleRetrieveMessages();
-//
-//        // Verify that the presenter method is called with the correct message history
-//        verify(presenter).prepareRoomView(messageHistory);
-//
-//        doNothing().when(messageInteractor).playLarkSound();
-//        //Verify that the interactor plays the lark sound
-//        verify(messageInteractor).playLarkSound();
-//    }
+
+    @Test
+    public void testHandleRetrieveMessages_WithLark(){
+        // Prepare the test data
+        String messageHistory = "User1: Hello\nUser2: /lark";
+        RoomDBModel mockedRoom = new RoomDBModel(Room.getRoomID(), "Test Room", hostID, new ArrayList<>(Arrays.asList(userID, userID2)), messageHistory);
+        when(database.getARoom(Room.getRoomID())).thenReturn(mockedRoom);
+
+        // Call the method to be tested
+        messageInteractor.handleRetrieveMessages();
+
+        // Verify that the presenter method is called with the correct message history
+        verify(presenter).prepareRoomView(messageHistory);
+
+        // Verify that the interactor calls the larkSoundPlayer to play the lark sound
+        verify(larkSoundPlayer).playLarkSound();
+    }
 }
-// Commented the lark testing because verify(...) is only allowed for mock but messageInteractor is not a mock
-// A solution was to make messageInteractor a spy, that did pass the test but didn't pass the auto-grading.
-
-

--- a/src/test/java/use_cases_and_adapters/messaging/MessagePresenterTest.java
+++ b/src/test/java/use_cases_and_adapters/messaging/MessagePresenterTest.java
@@ -22,9 +22,12 @@ public class MessagePresenterTest {
         String messageHistory = "Old message\\nNew message";
 
         messagePresenter.prepareRoomView(messageHistory);
-        verify(mockView, times(1)).prepareGUI();
+        verify(mockView, times(1)).prepareGUI(messageHistory);
     }
-    // omitted testing the prepareMessageErrorView method because it relies on a static method from Swing
-    // omitted testing the setView method because it is just a setter
 
+    @Test
+    void testPrepareMessageErrorView() {
+        messagePresenter.prepareMessageErrorView();
+        verify(mockView, times(1)).displayPopUpMessage("You cannot send an empty message!");
+    }
 }

--- a/src/test/java/use_cases_and_adapters/user_login/UserLoginPresenterTest.java
+++ b/src/test/java/use_cases_and_adapters/user_login/UserLoginPresenterTest.java
@@ -33,11 +33,20 @@ public class UserLoginPresenterTest {
         presenter.prepareJoinOrHostView();
 
         // checks that mockView calls prepareGUI exactly once
-        verify(mockView, times(1)).prepareGUI();
+        verify(mockView, times(1)).prepareGUI(null);
     }
 
-    // omitted testing the prepareInvalidUsernameView and prepareInvalidPasswordView
-    // because they rely on a static method from Swing
+    @Test
+    void testPrepareInvalidUsernameView() {
+        presenter.prepareInvalidUsernameView();
+        verify(mockView, times(1)).displayPopUpMessage(
+                "Username does not exist."); // check that prepareGUI was called
+    }
 
-    // omitted testing the setView method because it is just a setter
+    @Test
+    void testPrepareInvalidPasswordView() {
+        presenter.prepareInvalidPasswordView();
+        verify(mockView, times(1)).displayPopUpMessage(
+                "Password doesn't match username."); // check that prepareGUI was called
+    }
 }

--- a/src/test/java/use_cases_and_adapters/user_signup/UserSignupPresenterTest.java
+++ b/src/test/java/use_cases_and_adapters/user_signup/UserSignupPresenterTest.java
@@ -38,7 +38,7 @@ class UserSignupPresenterTest {
 
     @Test
     void testPrepareUsernameExistsView() {
-        userRegisterPresenter.prepareUsernameExistsView();
+        presenter.prepareUsernameExistsView();
         verify(mockView, times(1)).displayPopUpMessage(
                 "Username already exists. Please try a different name."); // check that prepareGUI was called
     }

--- a/src/test/java/use_cases_and_adapters/user_signup/UserSignupPresenterTest.java
+++ b/src/test/java/use_cases_and_adapters/user_signup/UserSignupPresenterTest.java
@@ -23,9 +23,13 @@ class UserSignupPresenterTest {
     @Test
     void testPrepareJoinOrHostView() {
         userRegisterPresenter.prepareJoinOrHostView();
-        verify(mockView, times(1)).prepareGUI(); // check that prepareGUI was called
+        verify(mockView, times(1)).prepareGUI(null); // check that prepareGUI was called
     }
 
-    // omitted testing the prepareInvalidCredentialsView method because it relies on a static method from Swing
-    // omitted testing the setView method because it is just a setter
+    @Test
+    void testPrepareUsernameExistsView() {
+        userRegisterPresenter.prepareUsernameExistsView();
+        verify(mockView, times(1)).displayPopUpMessage(
+                "Username already exists. Please try a different name."); // check that prepareGUI was called
+    }
 }


### PR DESCRIPTION
We had two remaining dependencies on `View` which I removed by modifying `Viewable` (when we updated message history). <br>
I also created a `displayPopUpMessage` method in `Viewable` so that now the presenters have 100% line coverage. I also moved the playLark method to the `database_and_drivers` package so that we obey CA and now the use cases are 100% testable. The `LarkSoundPlayer` is 100% covered too but only one test is headless so I commented the other one out like @Weihan1 did. Not a lot of new code here - just wrapping up some clean architecture loose ends (please merge in #130 before this one)